### PR TITLE
Generate icons with no border where appropriate

### DIFF
--- a/kolibri_app_desktop_xdg_plugin/path_utils.py
+++ b/kolibri_app_desktop_xdg_plugin/path_utils.py
@@ -27,9 +27,3 @@ def try_remove(file_path):
         os.remove(file_path)
     except Exception:
         pass
-
-
-def is_subdir(subdir, basedir):
-    subdir = os.path.abspath(subdir)
-    basedir = os.path.abspath(basedir)
-    return subdir.startswith(basedir)

--- a/kolibri_app_desktop_xdg_plugin/pillow_utils.py
+++ b/kolibri_app_desktop_xdg_plugin/pillow_utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from PIL import Image
+from PIL import ImageChops
 
 
 def pil_formats_for_mimetype(mimetype):
@@ -24,95 +25,27 @@ def paste_center(base_image, paste_image, **kwargs):
 
 def resize_preserving_aspect_ratio(source_image, target_size, **kwargs):
     source_size_square = (max(source_image.size),) * 2
-    frame_image = Image.new("RGBA", source_size_square, (255, 255, 255, 0))
+    frame_image = Image.new("RGBA", source_size_square, (0, 0, 0, 0))
     paste_center(frame_image, source_image)
     return frame_image.resize(target_size, **kwargs)
 
 
-def draw_rounded_rectangle(draw, xy, radius=0, fill=None, outline=None, width=1):
-    # TODO: This is from <https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageDraw.py#L260-L348>
-    #       Replace this once Pillow 8.2.0 is released.
+def crop_image_to_square(image, cut_area):
+    width, height = image.size
+    short_edge = min(width, height)
+    off_square = abs(1 - (width / height))
 
-    if isinstance(xy[0], (list, tuple)):
-        (x0, y0), (x1, y1) = xy
-    else:
-        x0, y0, x1, y1 = xy
+    if off_square == 0 or off_square > cut_area:
+        return image
 
-    d = radius * 2
+    return image.crop(center_xy(image.size, (short_edge,) * 2))
 
-    full_x = d >= x1 - x0
-    if full_x:
-        # The two left and two right corners are joined
-        d = x1 - x0
-    full_y = d >= y1 - y0
-    if full_y:
-        # The two top and two bottom corners are joined
-        d = y1 - y0
-    if full_x and full_y:
-        # If all corners are joined, that is a circle
-        return draw.ellipse(xy, fill, outline, width)
 
-    if d == 0:
-        # If the corners have no curve, that is a rectangle
-        return draw.rectangle(xy, fill, outline, width)
+def image_is_square(image):
+    if image.size[0] != image.size[1]:
+        return False
 
-    ink, fill = draw._getink(outline, fill)
+    square = Image.new("L", image.size, (255,))
+    diff = ImageChops.difference(image.getchannel("A"), square)
 
-    def draw_corners(pieslice):
-        if full_x:
-            # Draw top and bottom halves
-            parts = (
-                ((x0, y0, x0 + d, y0 + d), 180, 360),
-                ((x0, y1 - d, x0 + d, y1), 0, 180),
-            )
-        elif full_y:
-            # Draw left and right halves
-            parts = (
-                ((x0, y0, x0 + d, y0 + d), 90, 270),
-                ((x1 - d, y0, x1, y0 + d), 270, 90),
-            )
-        else:
-            # Draw four separate corners
-            parts = (
-                ((x1 - d, y0, x1, y0 + d), 270, 360),
-                ((x1 - d, y1 - d, x1, y1), 0, 90),
-                ((x0, y1 - d, x0 + d, y1), 90, 180),
-                ((x0, y0, x0 + d, y0 + d), 180, 270),
-            )
-        for part in parts:
-            if pieslice:
-                draw.draw.draw_pieslice(*(part + (fill, 1)))
-            else:
-                draw.draw.draw_arc(*(part + (ink, width)))
-
-    if fill is not None:
-        draw_corners(True)
-
-        if full_x:
-            draw.draw.draw_rectangle((x0, y0 + d / 2 + 1, x1, y1 - d / 2 - 1), fill, 1)
-        else:
-            draw.draw.draw_rectangle((x0 + d / 2 + 1, y0, x1 - d / 2 - 1, y1), fill, 1)
-        if not full_x and not full_y:
-            draw.draw.draw_rectangle(
-                (x0, y0 + d / 2 + 1, x0 + d / 2, y1 - d / 2 - 1), fill, 1
-            )
-            draw.draw.draw_rectangle(
-                (x1 - d / 2, y0 + d / 2 + 1, x1, y1 - d / 2 - 1), fill, 1
-            )
-    if ink is not None and ink != fill and width != 0:
-        draw_corners(False)
-
-        if not full_x:
-            draw.draw.draw_rectangle(
-                (x0 + d / 2 + 1, y0, x1 - d / 2 - 1, y0 + width - 1), ink, 1
-            )
-            draw.draw.draw_rectangle(
-                (x0 + d / 2 + 1, y1 - width + 1, x1 - d / 2 - 1, y1), ink, 1
-            )
-        if not full_y:
-            draw.draw.draw_rectangle(
-                (x0, y0 + d / 2 + 1, x0 + width - 1, y1 - d / 2 - 1), ink, 1
-            )
-            draw.draw.draw_rectangle(
-                (x1 - width + 1, y0 + d / 2 + 1, x1, y1 - d / 2 - 1), ink, 1
-            )
+    return not diff.getbbox()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     license="MIT",
     keywords="kolibri",
-    install_requires=["kolibri>=0.14.6", "Pillow>=8.1.2"],
+    install_requires=["kolibri>=0.14.6", "Pillow>=8.2.0"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
For channels with thumbnails matching a particular set of constraints,
we will generate icons where the thumbnail fills all available space.

https://phabricator.endlessm.com/T32101

While we're at it, we can update the minimum version of Pillow and remove our local copy of `ImageDraw.rounded_rectangle`.