### PR TITLE
Set TryExec pointing to kolibri-gnome full path

### DIFF
--- a/kolibri_app_desktop_xdg_plugin/channel_launchers.py
+++ b/kolibri_app_desktop_xdg_plugin/channel_launchers.py
@@ -18,6 +18,7 @@ from PIL import ImageDraw
 
 from .path_utils import ensure_dir
 from .path_utils import get_content_share_dir_path
+from .path_utils import get_kolibri_gnome_path
 from .path_utils import try_remove
 from .pillow_utils import center_xy
 from .pillow_utils import crop_image_to_square
@@ -211,6 +212,10 @@ class ChannelLauncher_FromDatabase(ChannelLauncher):
 
         if icon_name:
             desktop_file_parser.set("Desktop Entry", "Icon", icon_name)
+
+        kolibri_gnome = get_kolibri_gnome_path()
+        if kolibri_gnome:
+            desktop_file_parser.set("Desktop Entry", "TryExec", kolibri_gnome)
 
         ensure_dir(self.desktop_file_path)
         with open(self.desktop_file_path, "w") as desktop_entry_file:

--- a/kolibri_app_desktop_xdg_plugin/path_utils.py
+++ b/kolibri_app_desktop_xdg_plugin/path_utils.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import configparser
 
 from kolibri.core.content.utils.paths import get_content_dir_path
 
@@ -27,3 +28,20 @@ def try_remove(file_path):
         os.remove(file_path)
     except Exception:
         pass
+
+
+def get_kolibri_gnome_path():
+    flatpak_info = "/.flatpak-info"
+    if not os.path.exists(flatpak_info):
+        return None
+
+    config = configparser.ConfigParser()
+    config.read(flatpak_info)
+    app_path = config["Instance"]["app-path"]
+    app_commit = config["Instance"]["app-commit"]
+
+    # Remove the commit to make it work with flatpak updates updates
+    app_path = app_path.replace(app_commit, "active")
+    path = os.path.join(app_path, "bin", "kolibri-gnome")
+
+    return path


### PR DESCRIPTION
This will hide the desktop icon if the flatpak application is removed
and the kolibri-gnome binary can't be found.

https://phabricator.endlessm.com/T32676