### PR TITLE
Update Pillow to 10.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     license="MIT",
     keywords="kolibri",
-    install_requires=["kolibri>=0.14.6", "Pillow>=8.2.0,<9.0.0"],
+    install_requires=["kolibri>=0.14.6", "Pillow>=10.1.0,<11.0.0"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
In b457d70, we started specifying a maximum version for Pillow. I wish in that commit I had left a note as to _why_, but in my own testing, Pillow 10.1.0 appears to work the same for our needs as Pillow 8.x did.